### PR TITLE
Add missing icon type on series[i]-line. symbol

### DIFF
--- a/cn/option-gl/partial/icon.md
+++ b/cn/option-gl/partial/icon.md
@@ -6,7 +6,7 @@ ECharts 提供的标记类型包括 {{ import: partial-icon-buildin}}
 
 
 {{ target: partial-icon-buildin}}
-`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`
+`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`, `'none'`
 
 
 {{ target: partial-icon-path }}

--- a/cn/option/partial/icon.md
+++ b/cn/option/partial/icon.md
@@ -31,7 +31,7 @@ URL 为 `dataURI` 例如：
 
 
 {{ target: partial-icon-buildin}}
-`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`
+`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`, `'none'`
 
 
 {{ target: partial-icon-path }}

--- a/en/option/partial/icon.md
+++ b/en/option/partial/icon.md
@@ -38,7 +38,7 @@ A `dataURI` example:
 
 
 {{ target: partial-icon-buildin}}
-`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`
+`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`, `'none'`
 
 
 {{ target: partial-icon-path }}


### PR DESCRIPTION
This PR adds the `none` icon type to the list of icon types present on the series[i]-line. symbol documentation. The use of the `none` icon type has the following result:

<img width="1440" alt="imagem" src="https://user-images.githubusercontent.com/23379223/41983341-b8f2e83c-7a25-11e8-9723-b8b673e78ac5.png">