### PR TITLE
fix: correct the default value of axis nameLocation in Engligh docs

### DIFF
--- a/en/option/component/axis-common.md
+++ b/en/option/component/axis-common.md
@@ -252,7 +252,7 @@ Option:
 
 Name of axis.
 
-#${prefix} nameLocation(string) = 'start'
+#${prefix} nameLocation(string) = 'end'
 
 Location of axis name.
 


### PR DESCRIPTION
The default value is 'end' instead of 'start'