### PR TITLE
Fix yAxis typo in markPoint Option docs

### DIFF
--- a/en/option/partial/mark-point.md
+++ b/en/option/partial/mark-point.md
@@ -56,7 +56,7 @@ data: [{{if: ${hasType} }}
         coord: [10, 20]
     }, {
         name: 'fixed x position',
-        yAixs: 10,
+        yAxis: 10,
         x: '90%'
     }, {{/if}}
     {


### PR DESCRIPTION
-fix yAxis typo in mark-point parameters: change all instances of yAixs to yAxis