### PR TITLE
change title data type from boolean to string in the toolbox component

### DIFF
--- a/en/option/component/toolbox.md
+++ b/en/option/component/toolbox.md
@@ -23,7 +23,7 @@ Align of label text: `'left'` / `'right'`.
 #### show(boolean) = true
 Whether to show the tool.
 
-#### title(boolean) = '${title}'
+#### title(string) = '${title}'
 
 #### icon
 {{ use: partial-icon-image-path }}


### PR DESCRIPTION
I noticed that inside the `features` API option of the toolbox component, the titles for each of the default toolbox features had `boolean` as the default data type instead of the intended `string`