### PR TITLE
fixes typos

### DIFF
--- a/en/option/component/visual-map-piecewise.md
+++ b/en/option/component/visual-map-piecewise.md
@@ -199,7 +199,7 @@ Default symbol (the shape of graphical element). Possible values are:
 
 {{ import: partial-icon-buildin}}
 
-The setting of visual channel `symbol` can refers to [visualMap-piecewise.inRange](~visualMap-piecewise.inRange) and [visualMap-piecewise.outOfRange](~visualMap-piecewise.outOfRange).
+The setting of visual channel `symbol` can refer to [visualMap-piecewise.inRange](~visualMap-piecewise.inRange) and [visualMap-piecewise.outOfRange](~visualMap-piecewise.outOfRange).
 
 When they are not specified, `itemSymbol` is adopted as the default value (but just used in visualMap component itself, not in chart).
 

--- a/en/option/partial/z-zlevel.md
+++ b/en/option/partial/z-zlevel.md
@@ -2,7 +2,7 @@
 
 #${prefix|default("#")} zlevel(number) = ${defaultZLevel|default(0)}
 
-`zlevel` value of all graghical elements in ${componentName}.
+`zlevel` value of all graphical elements in ${componentName}.
 
 `zlevel` is used to make layers with Canvas. Graphical elements with different `zlevel` values will be placed in different Canvases, which is a common optimization technique. We can put those frequently changed elements (like those with animations) to a seperate `zlevel`. Notice that too many Canvases will increase memory cost, and should be used carefully on mobile phones to avoid crash.
 
@@ -10,6 +10,6 @@ Canvases with bigger `zlevel` will be placed on Canvases with smaller `zlevel`.
 
 #${prefix|default("#")} z(number) = ${defaultZ|default(2)}
 
-`z` value of all graghical elements in ${componentName}, which controls order of drawing graphical components. Components with smaller `z` values may be overwritten by those with larger `z` values.
+`z` value of all graphical elements in ${componentName}, which controls order of drawing graphical components. Components with smaller `z` values may be overwritten by those with larger `z` values.
 
 `z` has a lower priority to `zlevel`, and will not create new Canvas.


### PR DESCRIPTION
Fixes a few typos in `visual-map-piecewise` and `z-level`